### PR TITLE
Add boundary checking to player and enemy entities

### DIFF
--- a/Enemy.py
+++ b/Enemy.py
@@ -38,6 +38,9 @@ class Enemy(Player.Player):
         movement = Vector.Vector.from_polar(min(self.more_stats["max_speed"], (player.pos - self.pos).distance) / Const.FPS, (player.pos - self.pos).angle)
         if bool(movement):
             self.pos = self.pos + movement
+        # Boundary check
+        self.pos.x = max(0, min(self.pos.x, Const.WINDOW_WIDTH))
+        self.pos.y = max(0, min(self.pos.y, Const.WINDOW_HEIGHT))
 
         if (player.pos - self.pos).distance <= self.more_stats["range"]:
             self.punch(player)

--- a/Player.py
+++ b/Player.py
@@ -54,8 +54,11 @@ class Player:
         movement = Vector.Vector(int(pgUtils.PygameUtils.is_key_held(pygame.K_d)) - int(pgUtils.PygameUtils.is_key_held(pygame.K_a)), int(pgUtils.PygameUtils.is_key_held(pygame.K_s)) - int(pgUtils.PygameUtils.is_key_held(pygame.K_w)))
         if bool(movement):
             movement.set_distance(distance)
-            self.stats["direction"] = movement.angle
+            self.stats[\"direction\"] = movement.angle
             self.pos += movement
+        # Boundary check
+        self.pos.x = max(0, min(self.pos.x, Const.WINDOW_WIDTH))
+        self.pos.y = max(0, min(self.pos.y, Const.WINDOW_HEIGHT))
         if pgUtils.PygameUtils.is_key_pressed(pygame.K_SPACE):
             self.punch(enemies)
 


### PR DESCRIPTION
Fixes #14 by adding boundary checking to player and enemy entities to prevent them from moving outside the game window.